### PR TITLE
Update fn.js to properly search for line endings on Windows

### DIFF
--- a/build/fn.js
+++ b/build/fn.js
@@ -136,7 +136,7 @@ var functions = {
         contents = this.readFile(pPackages[packageName][fileExt]);
 
         // #37
-        if (contents.search(/\/\n*$/) === -1){
+        if (contents.search(/\/(\r?\n)*$/) === -1){
           console.log('File missing "/" at end: ' + pPackages[packageName][fileExt]);
           error = true;
         }

--- a/source/future/oos_util_transform.pkb
+++ b/source/future/oos_util_transform.pkb
@@ -2,9 +2,9 @@ create or replace package body oos_util_transform as
 
   /**
    * converts a ref cursor to a canonical oracle xml
-   * notes:
-   *  - this is just a wrapper for dbms_xmlgen so refer to oracle documentation
-   *  - http://docs.oracle.com/cd/E11882_01/appdev.112/e40758/d_xmlgen.htm
+   * Notes:
+   *  - This is just a wrapper for dbms_xmlgen so refer to the [Oracle documentation](http://docs.oracle.com/cd/E11882_01/appdev.112/e40758/d_xmlgen.htm)
+   *
    *
    * @example
    * declare


### PR DESCRIPTION
The regex to validate that a script ends with `/` now allows for both LF or CRLF line endings

Fixes #116.