### PR TITLE
Epoch functions

### DIFF
--- a/source/packages/oos_util_date.pks
+++ b/source/packages/oos_util_date.pks
@@ -1,17 +1,14 @@
 create or replace package oos_util_date
 as
-
   function date2epoch(
-    p_date in date)
+    p_date timestamp,
+    p_date_in_tzr in varchar2 default sessiontimezone)
     return number;
 
   function epoch2date(
-    p_epoch in number)
-    return date;
-
-  function timestamp2epoch(
-    p_timestamp in timestamp)
-    return pls_integer;
+    p_epoch in number,
+    p_date_out_tzr in varchar2 default sessiontimezone)
+    return timestamp with time zone;
 
 end oos_util_date;
 /


### PR DESCRIPTION
Alternative implementation. Removed timestamp2epoch in favor of implicit data conversion. Here, date2epoch uses the timestamp data type so if a date is passed it doesn't lose precision but any timestamp data type can be passed without losing milliseconds.

Also, both functions now have an additional tzr parameter which allows for additional flexibility when needed. In the case of date2epoch, the parameter can be used to specify which timezone the date or timestamp being passed in is from. For epoch2date, the tzr parameter allows the user to get a date back in a specific timezone.

The tzr parameter defaults to the sessiontimezone for convenience.